### PR TITLE
fix: Incomplete multi-line translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "baidu-translate",
   "displayName": "baidu-translate",
   "description": "baidu translate source for comment-translate",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publisher": "webxmsj",
   "engines": {
     "vscode": "^1.63.0"

--- a/src/baiduTranslate.ts
+++ b/src/baiduTranslate.ts
@@ -116,7 +116,11 @@ export class BaiduTranslate implements ITranslate {
     let res = await sendRequest<Response>(
       `${url}?${querystring.stringify(data)}`
     );
-    return res.trans_result[0].dst;
+    // Fix #3
+    // support multi-line translation results
+    // concat all the translation result with '\n'
+    const result = res.trans_result.map(({ dst }) => dst).join('\n');
+    return result;
   }
 
   link(content: string, { to = "auto", from = "auto" }: ITranslateOptions) {


### PR DESCRIPTION
Solved an issue with translation functionality where multi-line text was not being fully translated. By default, Baidu Translate API is to treat strings separated by '\n' as separate entities, but the code only extracted and displayed the first output.

**Issue Description:**
- The original code only extracted the translation result located at index 0, which meant that when attempting to translate multi-line text, only the first line was translated and shown. Actually, all subsequent lines were ignored.

**Changes Made:**
- I've modified the code to concatenate multiple translation results using the `join` method with '\n' as the separator. This allows the translation of multi-line text to be properly handled and displayed.

- Also updated the version number.

---

修复了翻译多行文本时翻译不完全的问题。默认情况下，百度翻译API以换行符'\n'切分输入翻译的字符串，并输出多个翻译结果，但代码只提取了第一个输出。

**问题描述:**
- 原始代码只提取了索引0处的翻译结果，这导致试图翻译多行文本时，只有第一行文本被翻译并显示，实际上忽略了所有后续行。

**更改内容:**
- 我更新了代码，使其能够聚合API返回的所有翻译结果，并用'\n'将它们连接起来，确保所有行的翻译文本都能正确拼接并显示。

- 同时更新了版本号

---

**Before:**

![3a8c39255d0143c9a744a0f5a0682f15](https://github.com/user-attachments/assets/75da4bc1-2cd1-420e-804e-9f323f430e2a)

![e249b01537dda87279677ba5e81bc249](https://github.com/user-attachments/assets/57251e7c-c65f-449e-9dd1-a8f4fa8444a6)


**After:**

![c0a4e7a3a838edbe58815f86d3c9b126](https://github.com/user-attachments/assets/22e61473-7d85-4fdd-a336-f45a3e28cfe1)

![b605ceb5e29c8e3ba48cfcaf172ddc1c](https://github.com/user-attachments/assets/d7909845-9ae6-4f0a-af83-3731453c1e3b)



closes #3